### PR TITLE
Separate Evaluation Script

### DIFF
--- a/datasets/base.py
+++ b/datasets/base.py
@@ -2,21 +2,24 @@
 # -*- coding: utf-8 -*-
 
 
-class SimDataset:
-
-    def training_partition(self):
-        raise NotImplementedError
-
-    def dev_partition(self):
-        raise NotImplementedError
-
-
 class SimDatasetPartition:
 
-    def nbatches(self):
+    def nbatches(self) -> int:
         raise NotImplementedError
 
     def __next__(self):
+        raise NotImplementedError
+
+
+class SimDataset:
+
+    def training_partition(self) -> SimDatasetPartition:
+        raise NotImplementedError
+
+    def dev_partition(self) -> SimDatasetPartition:
+        raise NotImplementedError
+
+    def test_partition(self) -> SimDatasetPartition:
         raise NotImplementedError
 
 
@@ -27,7 +30,7 @@ class LoaderWrapperPartition(SimDatasetPartition):
         self.loader = loader
         self.iterator = iter(loader)
 
-    def nbatches(self):
+    def nbatches(self) -> int:
         return len(self.loader)
 
     def __next__(self):

--- a/datasets/mnist.py
+++ b/datasets/mnist.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 from torchvision import datasets, transforms
 from torch.utils.data import DataLoader
-from datasets.base import SimDataset, LoaderWrapperPartition
+from datasets.base import SimDataset, LoaderWrapperPartition, SimDatasetPartition
 
 
 class MNIST(SimDataset):
@@ -16,8 +16,11 @@ class MNIST(SimDataset):
         self.trainset = datasets.MNIST(path, download=True, train=True, transform=transform)
         self.testset = datasets.MNIST(path, download=True, train=False, transform=transform)
 
-    def training_partition(self):
+    def training_partition(self) -> SimDatasetPartition:
         return LoaderWrapperPartition(DataLoader(self.trainset, self.batch_size, shuffle=True, num_workers=4))
 
-    def dev_partition(self):
+    def dev_partition(self) -> SimDatasetPartition:
         return LoaderWrapperPartition(DataLoader(self.testset, self.batch_size, shuffle=False, num_workers=4))
+
+    def test_partition(self) -> SimDatasetPartition:
+        return self.dev_partition()

--- a/datasets/semeval.py
+++ b/datasets/semeval.py
@@ -117,6 +117,7 @@ class SemEval(SimDataset):
         adev, bdev, simdev = self._load_partition('dev')
         atest, btest, simtest = self._load_partition('test')
         self.dev_sents = np.array(list(zip(zip(adev, bdev), simdev)))
+        self.test_sents = np.array(list(zip(zip(atest, btest), simtest)))
         if mode == 'clusters':
             sents_a = atrain + adev + atest
             sents_b = btrain + bdev + btest
@@ -169,13 +170,17 @@ class SemEval(SimDataset):
         else:
             raise ValueError("Mode can only be 'baseline', 'clusters', 'pairs' or 'triplets'")
 
-    def training_partition(self):
+    def training_partition(self) -> SimDatasetPartition:
         np.random.shuffle(self.train_sents)
         return SemEvalPartitionBuilder(self.batch_size, self.mode).build(self.train_sents, train=True)
 
-    def dev_partition(self):
+    def dev_partition(self) -> SimDatasetPartition:
         np.random.shuffle(self.dev_sents)
         return SemEvalPartitionBuilder(self.batch_size, self.mode).build(self.dev_sents, train=False)
+
+    def test_partition(self) -> SimDatasetPartition:
+        np.random.shuffle(self.test_sents)
+        return SemEvalPartitionBuilder(self.batch_size, self.mode).build(self.test_sents, train=False)
 
     def _load_partition(self, partition):
         with open(join(self.path, partition, 'a.toks')) as afile, \

--- a/datasets/voxceleb.py
+++ b/datasets/voxceleb.py
@@ -38,26 +38,37 @@ class VoxCelebPartition(SimDatasetPartition):
 
 class VoxCeleb1(SimDataset):
 
-    def __init__(self, batch_size, segment_size_millis):
+    def __init__(self, batch_size: int, segment_size_millis: int):
         sample_rate = 16000
-        segment_size_s = segment_size_millis / 1000
-        print(f"Segment Size = {segment_size_s}s")
+        self.batch_size = batch_size
+        self.segment_size_s = segment_size_millis / 1000
         self.nfeat = sample_rate * segment_size_millis // 1000
-        print(f"Embedding Size = {self.nfeat}")
         self.config = SpeakerValidationConfig(protocol_name='VoxCeleb.SpeakerVerification.VoxCeleb1_X',
                                               feature_extraction=RawAudio(sample_rate=sample_rate),
                                               preprocessors={'audio': FileFinder()},
-                                              duration=segment_size_s)
-        protocol = get_protocol(self.config.protocol_name, preprocessors=self.config.preprocessors)
-        self.train_gen = SpeechSegmentGenerator(self.config.feature_extraction, protocol,
-                                                subset='train', per_label=1, per_fold=batch_size,
-                                                duration=segment_size_s, parallel=3)
-        self.dev_gen = SpeechSegmentGenerator(self.config.feature_extraction, protocol,
-                                              subset='development', per_label=1, per_fold=batch_size,
-                                              duration=segment_size_s, parallel=2)
+                                              duration=self.segment_size_s)
+        self.protocol = get_protocol(self.config.protocol_name, preprocessors=self.config.preprocessors)
+        self.train_gen, self.dev_gen, self.test_gen = None, None, None
+        print(f"Segment Size = {self.segment_size_s}s")
+        print(f"Embedding Size = {self.nfeat}")
 
-    def training_partition(self):
+    def training_partition(self) -> SimDatasetPartition:
+        if self.train_gen is None:
+            self.train_gen = SpeechSegmentGenerator(self.config.feature_extraction, self.protocol,
+                                                    subset='train', per_label=1, per_fold=self.batch_size,
+                                                    duration=self.segment_size_s, parallel=3)
         return VoxCelebPartition(self.train_gen, self.nfeat)
 
-    def dev_partition(self):
+    def dev_partition(self) -> SimDatasetPartition:
+        if self.dev_gen is None:
+            self.dev_gen = SpeechSegmentGenerator(self.config.feature_extraction, self.protocol,
+                                                  subset='development', per_label=1, per_fold=self.batch_size,
+                                                  duration=self.segment_size_s, parallel=2)
         return VoxCelebPartition(self.dev_gen, self.nfeat)
+
+    def test_partition(self) -> SimDatasetPartition:
+        if self.test_gen is None:
+            self.test_gen = SpeechSegmentGenerator(self.config.feature_extraction, self.protocol,
+                                                   subset='test', per_label=1, per_fold=self.batch_size,
+                                                   duration=self.segment_size_s, parallel=2)
+        return VoxCelebPartition(self.test_gen, self.nfeat)

--- a/eval.py
+++ b/eval.py
@@ -1,0 +1,27 @@
+import argparse
+from utils import set_custom_seed, DEVICE
+from distances import EuclideanDistance, CosineDistance
+from experiments import VoxCeleb1ModelEvaluationExperiment
+
+
+# Script arguments
+parser = argparse.ArgumentParser()
+parser.add_argument('--distance', type=str, default='euclidean', help='cosine / euclidean. Default: euclidean')
+parser.add_argument('--batch-size', type=int, default=100, help='Batch size for training and testing')
+parser.add_argument('--model', type=str, default=None, help='The path to the saved model to evaluate')
+args = parser.parse_args()
+
+# Set custom seed
+set_custom_seed()
+
+print('[Preparing...]')
+nfeat, nclass = 256, 1251
+distance = CosineDistance() if args.distance == 'cosine' else EuclideanDistance()
+experiment = VoxCeleb1ModelEvaluationExperiment(model_path=args.model,
+                                                nfeat=nfeat,
+                                                distance=distance,
+                                                device=DEVICE,
+                                                batch_size=args.batch_size)
+print('[Started Evaluation...]')
+eer = experiment.evaluate_on_test()
+print(f"[Evaluation Finished. TEST EER = {eer}]")

--- a/eval.py
+++ b/eval.py
@@ -1,27 +1,54 @@
 import argparse
-from utils import set_custom_seed, DEVICE
+from utils import set_custom_seed
 from distances import EuclideanDistance, CosineDistance
-from experiments import VoxCeleb1ModelEvaluationExperiment
-
+from experiments import VoxCeleb1ModelEvaluationExperiment, SemEvalModelEvaluationExperiment
 
 # Script arguments
 parser = argparse.ArgumentParser()
+parser.add_argument('--task', type=str, required=True, help='speaker / sts')
+parser.add_argument('--model', type=str, required=True, help='The path to the saved model to evaluate')
+parser.add_argument('--partition', type=str, default='test', help='dev / test. Default: test')
 parser.add_argument('--distance', type=str, default='euclidean', help='cosine / euclidean. Default: euclidean')
 parser.add_argument('--batch-size', type=int, default=100, help='Batch size for training and testing')
-parser.add_argument('--model', type=str, default=None, help='The path to the saved model to evaluate')
+parser.add_argument('--sts-path', type=str, default=None, help='Path to SemEval dataset')
+parser.add_argument('--vocab', type=str, default=None, help='Path to vocabulary file for STS')
+parser.add_argument('--word2vec', type=str, default=None, help='Path to word embeddings for STS')
+parser.add_argument('--log-interval', type=int, default=10,
+                    help='Steps (in percentage) to show evaluation progress, only for STS. Default: 10')
 args = parser.parse_args()
 
 # Set custom seed
 set_custom_seed()
 
-print('[Preparing...]')
-nfeat, nclass = 256, 1251
 distance = CosineDistance() if args.distance == 'cosine' else EuclideanDistance()
-experiment = VoxCeleb1ModelEvaluationExperiment(model_path=args.model,
-                                                nfeat=nfeat,
-                                                distance=distance,
-                                                device=DEVICE,
-                                                batch_size=args.batch_size)
+
+print(f"[Task: {args.task.upper()}]")
+
+print('[Preparing...]')
+if args.task == 'speaker':
+    experiment = VoxCeleb1ModelEvaluationExperiment(model_path=args.model,
+                                                    nfeat=256,
+                                                    distance=distance,
+                                                    batch_size=args.batch_size)
+    result_format = "[{partition} EER = {metric}]"
+elif args.task == 'sts':
+    experiment = SemEvalModelEvaluationExperiment(model_path=args.model,
+                                                  nfeat=500,
+                                                  data_path=args.sts_path,
+                                                  word2vec_path=args.word2vec,
+                                                  vocab_path=args.vocab,
+                                                  distance=distance,
+                                                  log_interval=args.log_interval,
+                                                  batch_size=args.batch_size)
+    result_format = "[{partition} Spearman = {metric}]"
+else:
+    raise ValueError("Task can only be 'speaker' or 'sts'")
+
 print('[Started Evaluation...]')
-eer = experiment.evaluate_on_test()
-print(f"[Evaluation Finished. TEST EER = {eer}]")
+if args.partition == 'dev':
+    metric = experiment.evaluate_on_dev()
+else:
+    metric = experiment.evaluate_on_test()
+print(f"[Evaluation Finished]")
+
+print(result_format.format(partition=args.partition.upper(), metric=metric))

--- a/experiments.py
+++ b/experiments.py
@@ -1,24 +1,67 @@
-from models import SpeakerNet
+from models import SpeakerNet, SemanticNet
 from distances import Distance
-from losses.base import ModelLoader
+from losses.base import ModelLoader, DeviceMapperTransform, TestLogger
 from datasets.voxceleb import VoxCeleb1
-from metrics import SpeakerVerificationEvaluator
+from datasets.semeval import SemEval
+from metrics import SpeakerVerificationEvaluator, STSEmbeddingEvaluator, DistanceSpearmanMetric
+from utils import DEVICE
 
 
-class VoxCeleb1ModelEvaluationExperiment:
+class ModelEvaluationExperiment:
 
-    def __init__(self, model_path: str, nfeat: int, distance: Distance, device: str, batch_size: int):
+    def evaluate_on_dev(self) -> float:
+        raise NotImplementedError
+
+    def evaluate_on_test(self) -> float:
+        raise NotImplementedError
+
+
+class VoxCeleb1ModelEvaluationExperiment(ModelEvaluationExperiment):
+
+    def __init__(self, model_path: str, nfeat: int, distance: Distance, batch_size: int):
         self.model = SpeakerNet(nfeat, sample_rate=16000, window=200)
         ModelLoader(None).load(self.model, model_path)
-        self.model = self.model.to_prediction_model()
-        self.dataset = VoxCeleb1(batch_size, segment_size_millis=200)
-        self.evaluator = SpeakerVerificationEvaluator(device, batch_size, distance,
-                                                      eval_interval=0, config=self.dataset.config)
+        self.model = self.model.to_prediction_model().to(DEVICE)
+        dataset = VoxCeleb1(batch_size, segment_size_millis=200)
+        self.evaluator = SpeakerVerificationEvaluator(DEVICE, batch_size, distance,
+                                                      eval_interval=0, config=dataset.config)
 
-    def evaluate_on_dev(self):
+    def evaluate_on_dev(self) -> float:
         inverse_eer = self.evaluator.eval(self.model, partition='dev')
         return 1 - inverse_eer
 
-    def evaluate_on_test(self):
+    def evaluate_on_test(self) -> float:
         inverse_eer = self.evaluator.eval(self.model, partition='test')
         return 1 - inverse_eer
+
+
+class SemEvalModelEvaluationExperiment(ModelEvaluationExperiment):
+
+    def __init__(self, model_path: str, nfeat: int, data_path: str, word2vec_path: str,
+                 vocab_path: str, distance: Distance, log_interval: int, batch_size: int):
+        # The mode and threshold are not important since we won't use any of this for training
+        self.dataset = SemEval(data_path, word2vec_path, vocab_path, batch_size)
+        # We can pass any mode but 'baseline' here, because we don't want to concatenate both embeddings in the end
+        self.model = SemanticNet(DEVICE, nfeat, self.dataset.vocab, mode='pairs')
+        ModelLoader(None).load(self.model, model_path)
+        self.model = self.model.to_prediction_model().to(DEVICE)
+        self.dev_evaluator, self.test_evaluator = None, None
+        self.log_interval = log_interval
+        self.distance = distance
+
+    def _build_evaluator(self, partition):
+        return STSEmbeddingEvaluator(DEVICE, partition, DistanceSpearmanMetric(self.distance),
+                                     batch_transforms=[DeviceMapperTransform(DEVICE)],
+                                     callbacks=[TestLogger(self.log_interval, partition.nbatches())])
+
+    def evaluate_on_dev(self) -> float:
+        if self.dev_evaluator is None:
+            self.dev_evaluator = self._build_evaluator(self.dataset.dev_partition())
+        self.dev_evaluator.eval(self.model)
+        return self.dev_evaluator.metric.get()
+
+    def evaluate_on_test(self) -> float:
+        if self.test_evaluator is None:
+            self.test_evaluator = self._build_evaluator(self.dataset.test_partition())
+        self.test_evaluator.eval(self.model)
+        return self.test_evaluator.metric.get()

--- a/experiments.py
+++ b/experiments.py
@@ -1,0 +1,24 @@
+from models import SpeakerNet
+from distances import Distance
+from losses.base import ModelLoader
+from datasets.voxceleb import VoxCeleb1
+from metrics import SpeakerVerificationEvaluator
+
+
+class VoxCeleb1ModelEvaluationExperiment:
+
+    def __init__(self, model_path: str, nfeat: int, distance: Distance, device: str, batch_size: int):
+        self.model = SpeakerNet(nfeat, sample_rate=16000, window=200)
+        ModelLoader(None).load(self.model, model_path)
+        self.model = self.model.to_prediction_model()
+        self.dataset = VoxCeleb1(batch_size, segment_size_millis=200)
+        self.evaluator = SpeakerVerificationEvaluator(device, batch_size, distance,
+                                                      eval_interval=0, config=self.dataset.config)
+
+    def evaluate_on_dev(self):
+        inverse_eer = self.evaluator.eval(self.model, partition='dev')
+        return 1 - inverse_eer
+
+    def evaluate_on_test(self):
+        inverse_eer = self.evaluator.eval(self.model, partition='test')
+        return 1 - inverse_eer

--- a/losses/center.py
+++ b/losses/center.py
@@ -4,6 +4,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
+
 class SoftmaxCenterLoss(nn.Module):
     """
     Cross Entropy + Center Loss module

--- a/metrics.py
+++ b/metrics.py
@@ -283,7 +283,7 @@ class STSEmbeddingEvaluator(TrainingListener):
         self.callbacks = callbacks
         self.best_metric, self.best_epoch = 0, -1
 
-    def _eval(self, model):
+    def eval(self, model):
         model.eval()
         feat_test, y_test = [], []
         for cb in self.callbacks:
@@ -321,7 +321,7 @@ class STSEmbeddingEvaluator(TrainingListener):
             self.best_metric = checkpoint['accuracy']
 
     def on_after_epoch(self, epoch, model, loss_fn, optim, mean_loss):
-        feat_test, y_test = self._eval(model.to_prediction_model())
+        feat_test, y_test = self.eval(model.to_prediction_model())
         metric_value = self.metric.get()
         print(f"--------------- Epoch {epoch:02d} Results ---------------")
         print(f"Dev Spearman: {metric_value:.6f}")

--- a/models.py
+++ b/models.py
@@ -133,8 +133,7 @@ class SemanticNet(SimNet):
 
     def __init__(self, device, nfeat, vector_vocab, loss_module=None, mode='baseline'):
         super().__init__(loss_module)
-        self.base_model = STSBaselineNet(device, nfeat_word=300, nfeat_sent=nfeat,
-                                         vec_vocab=vector_vocab, tokens=vector_vocab.keys(), mode=mode)
+        self.base_model = STSBaselineNet(device, nfeat_word=300, nfeat_sent=nfeat, vec_vocab=vector_vocab, mode=mode)
 
     def layers(self):
         return [self.base_model]

--- a/sts_baseline.py
+++ b/sts_baseline.py
@@ -4,29 +4,6 @@ import torch.nn as nn
 import numpy
 
 
-# This function was an attempt to solve a vanishing gradient
-# We can remove it if it doesn't prove useful
-def set_forget_gate_bias(lstm: nn.LSTM, value: float):
-    """
-    Set forget bias of the given LSTM module to `value`.
-    Pytorch guarantees the following fixed positions for LSTM biases:
-
-    [input_gate | forget_gate | cell_gate | output_gate]
-    0          n/4           n/2         3n/4          n
-                ^             ^
-                |_____________|
-                 we want this!
-
-    Reference: https://discuss.pytorch.org/t/set-forget-gate-bias-of-lstm/1745
-    """
-    for names in lstm._all_weights:
-        for name in filter(lambda n: "bias" in n, names):
-            bias = getattr(lstm, name)
-            n = bias.size(0)
-            start, end = n // 4, n // 2
-            bias.data[start:end].fill_(value)
-
-
 class STSBaselineNet(nn.Module):
 
     def __init__(self, device, nfeat_word, nfeat_sent, vec_vocab, mode='baseline'):
@@ -49,7 +26,7 @@ class STSBaselineNet(nn.Module):
         self.lstm = nn.LSTM(input_size=nfeat_word, hidden_size=nfeat_sent // 2,
                             num_layers=1, bidirectional=True)
 
-    def word_layer(self, sent):
+    def _to_word_embeddings(self, sent):
         tmp = []
         for word in sent:
             if word in self.word2id:
@@ -60,57 +37,35 @@ class STSBaselineNet(nn.Module):
         embedded_sent = self.word_embedding(indices)
         return embedded_sent.view(-1, 1, self.nfeat_word)
 
+    def _embed(self, sent):
+        x = self._to_word_embeddings(sent)
+        out, _ = self.lstm(x)
+        # Max pooling to get the embedding
+        embedding = torch.max(out, 0)[0]
+        return embedding
+
     def forward(self, sents):
         # FIXME Replace this with subclasses or (preferably) delegation
-        if not self.training:
-            if self.mode == 'baseline':
-                return self._forward_pair_concat(sents)
-            else:
-                return self._forward_pair(sents)
-        elif self.mode == 'baseline':
+        if self.mode == 'baseline':
             return self._forward_pair_concat(sents)
+        elif not self.training:
+            return self._forward_pair(sents)
         elif self.mode == 'pairs':
             return self._forward_pair(sents)
         else:
             return self._forward_single(sents)
 
     def _forward_single(self, sents):
-        embeds = []
-        for sent in sents:
-            x = self.word_layer(sent)
-            # Encode input
-            out, _ = self.lstm(x)
-            # Max pooling to get embeddings
-            embed = torch.max(out, 0)[0]
-            embeds.append(embed)
-        return torch.stack(embeds, dim=0).squeeze()
+        embs = [self._embed(sent) for sent in sents]
+        return torch.stack(embs, dim=0).squeeze()
 
     def _forward_pair_concat(self, sents):
-        embeds = []
-        for s1, s2 in sents:
-            x1 = self.word_layer(s1)
-            x2 = self.word_layer(s2)
-            # Encode input
-            out1, _ = self.lstm(x1)
-            out2, _ = self.lstm(x2)
-            # Max pooling to get embeddings
-            embed1 = torch.max(out1, 0)[0]
-            embed2 = torch.max(out2, 0)[0]
-            embed = torch.cat((embed1, embed2), 1)
-            embeds.append(embed)
-        return torch.stack(embeds, dim=0).squeeze()
+        embs = [torch.cat((self._embed(s1), self._embed(s2)), 1) for s1, s2 in sents]
+        return torch.stack(embs, dim=0).squeeze()
 
     def _forward_pair(self, sents):
-        embeds1, embeds2 = [], []
+        embs1, embs2 = [], []
         for s1, s2 in sents:
-            x1 = self.word_layer(s1)
-            x2 = self.word_layer(s2)
-            # Encode input
-            out1, _ = self.lstm(x1)
-            out2, _ = self.lstm(x2)
-            # Max pooling to get embeddings
-            embed1 = torch.max(out1, 0)[0]
-            embed2 = torch.max(out2, 0)[0]
-            embeds1.append(embed1)
-            embeds2.append(embed2)
-        return torch.stack(embeds1, dim=0).squeeze(), torch.stack(embeds2, dim=0).squeeze()
+            embs1.append(self._embed(s1))
+            embs2.append(self._embed(s2))
+        return torch.stack(embs1, dim=0).squeeze(), torch.stack(embs2, dim=0).squeeze()

--- a/sts_baseline.py
+++ b/sts_baseline.py
@@ -29,12 +29,13 @@ def set_forget_gate_bias(lstm: nn.LSTM, value: float):
 
 class STSBaselineNet(nn.Module):
 
-    def __init__(self, device, nfeat_word, nfeat_sent, vec_vocab, tokens, mode='baseline'):
+    def __init__(self, device, nfeat_word, nfeat_sent, vec_vocab, mode='baseline'):
         super(STSBaselineNet, self).__init__()
         self.device = device
         self.nfeat_word = nfeat_word
         self.nfeat_sent = nfeat_sent
         self.mode = mode
+        tokens = vec_vocab.keys()
         if 'oov' not in tokens:
             tokens.append('oov')
         self.word2id = {word: index for index, word in enumerate(tokens)}

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,75 @@
+import torch
+import numpy as np
+import random
+import losses.config as cf
+from distances import CosineDistance
+
+
+"""
+A string to explain all possible loss names
+"""
+LOSS_OPTIONS_STR = 'softmax / contrastive / triplet / arcface / center / coco'
+
+"""
+Common seed for every script
+"""
+SEED = 124
+
+"""
+PyTorch device: GPU if available, CPU otherwise
+"""
+_use_cuda = torch.cuda.is_available() and True
+# TODO This device is a constant for everyone, we can remove the 'device' parameters and use this directly
+# TODO or maybe create a singleton object
+DEVICE = torch.device('cuda' if _use_cuda else 'cpu')
+
+
+def set_custom_seed():
+    """
+    Set the same seed for all sources of random computations
+    :return: nothing
+    """
+    print(f"[Seed: {SEED}]")
+    torch.manual_seed(SEED)
+    np.random.seed(SEED)
+    random.seed(SEED)
+
+
+def enabled_str(value: bool) -> str:
+    """
+    :param value: a boolean
+    :return: ENABLED if value is True, DISABLED otherwise
+    """
+    return 'ENABLED' if value else 'DISABLED'
+
+
+def get_config(loss: str, nfeat: int, nclass: int, task: str, device: str) -> cf.LossConfig:
+    """
+    Create a loss configuration object based on parameteres given by the user
+    :param loss: the loss function name
+    :param nfeat: the dimension of the embeddings
+    :param nclass: the number of classes
+    :param task: the task for which the loss will be used
+    :param device: a PyTorch device string
+    :return: a loss configuration object
+    """
+    if loss == 'softmax':
+        return cf.SoftmaxConfig(device, nfeat, nclass)
+    elif loss == 'contrastive':
+        return cf.ContrastiveConfig(device,
+                                    margin=0.15,
+                                    distance=CosineDistance(),
+                                    size_average=False,
+                                    online=task != 'sts')
+    elif loss == 'triplet':
+        return cf.TripletConfig(device)
+    elif loss == 'arcface':
+        return cf.ArcFaceConfig(device, nfeat, nclass)
+    elif loss == 'center':
+        return cf.CenterConfig(device, nfeat, nclass, distance=CosineDistance())
+    elif loss == 'coco':
+        return cf.CocoConfig(device, nfeat, nclass)
+    elif loss == 'kldiv':
+        return cf.KLDivergenceConfig(device, nfeat)
+    else:
+        raise ValueError(f"Loss function should be one of: {LOSS_OPTIONS_STR}")


### PR DESCRIPTION
## Biggest Changes
- Added Evaluation Experiment classes for speaker verification and sts to abstract away all the ugly configuration needed to test a model
- Added a new `eval.py` script that only tests a saved model
- Cleaned sts baseline code
- Added (but still not using) forward modes for the sts baseline model. The idea is to put this logic in strategy-like objects so it's cleaner and less hard-coded